### PR TITLE
Scan for boot files at run time.

### DIFF
--- a/data/usbbootgui.ui
+++ b/data/usbbootgui.ui
@@ -18,16 +18,6 @@
     </columns>
     <data>
       <row>
-        <col id="0">gpio.png</col>
-        <col id="1" translatable="yes">GPIO expansion board</col>
-        <col id="2">gpioexpand</col>
-      </row>
-      <row>
-        <col id="0">sdcard.png</col>
-        <col id="1" translatable="yes">eMMC / SD card reader</col>
-        <col id="2">msd</col>
-      </row>
-      <row>
         <col id="0">document-open.png</col>
         <col id="1" translatable="yes">Custom application</col>
         <col id="2" translatable="yes"/>
@@ -78,7 +68,7 @@
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
@@ -142,43 +132,50 @@ Type: </property>
               </packing>
             </child>
             <child>
-              <object class="GtkTreeView" id="treeview">
-                <property name="height_request">200</property>
+              <object class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="model">liststore</property>
-                <property name="headers_visible">False</property>
-                <property name="search_column">7</property>
+                <property name="hscrollbar_policy">automatic</property>
+                <property name="vscrollbar_policy">automatic</property>
                 <child>
-                  <object class="GtkTreeViewColumn" id="treeviewcolumn1">
-                    <property name="fixed_width">64</property>
-                    <property name="min_width">64</property>
-                    <property name="title" translatable="yes">icon</property>
+                  <object class="GtkTreeView" id="treeview">
+                    <property name="height_request">200</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="model">liststore</property>
+                    <property name="headers_visible">False</property>
+                    <property name="search_column">7</property>
                     <child>
-                      <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf1"/>
-                      <attributes>
-                        <attribute name="pixbuf">0</attribute>
-                      </attributes>
+                      <object class="GtkTreeViewColumn" id="treeviewcolumn1">
+                        <property name="fixed_width">64</property>
+                        <property name="min_width">64</property>
+                        <property name="title" translatable="yes">icon</property>
+                        <child>
+                          <object class="GtkCellRendererPixbuf" id="cellrendererpixbuf1"/>
+                          <attributes>
+                            <attribute name="pixbuf">0</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkTreeViewColumn" id="treeviewcolumn2">
+                        <property name="title" translatable="yes">description</property>
+                        <child>
+                          <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                          <attributes>
+                            <attribute name="markup">1</attribute>
+                          </attributes>
+                        </child>
+                      </object>
                     </child>
                   </object>
-                </child>
-                <child>
-                  <object class="GtkTreeViewColumn" id="treeviewcolumn2">
-                    <property name="title" translatable="yes">description</property>
-                    <child>
-                      <object class="GtkCellRendererText" id="cellrenderertext1"/>
-                      <attributes>
-                        <attribute name="text">1</attribute>
-                      </attributes>
-                    </child>
-                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
             </child>
             <child>
               <object class="GtkCheckButton" id="alwayscheck">
@@ -189,7 +186,7 @@ Type: </property>
                 <property name="draw_indicator">True</property>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">3</property>
               </packing>

--- a/data/usbbootgui.ui
+++ b/data/usbbootgui.ui
@@ -169,11 +169,6 @@ Type: </property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
             </child>

--- a/src/usbbootgui.c
+++ b/src/usbbootgui.c
@@ -521,8 +521,6 @@ static void scanDirectory(const gchar *path)
 	const gchar *name;
 	GDir *rpibootdir;
 
-	printf("scanning %s\n", path);
-
 	rpibootpath = g_strdup_printf ("%s/rpiboot", path);
 	rpibootdir = g_dir_open(rpibootpath, 0, NULL);
 	if (!rpibootdir)

--- a/src/usbbootgui.c
+++ b/src/usbbootgui.c
@@ -76,7 +76,7 @@ static gchar *promptForFolder()
 
 	gtk_widget_destroy (dialog);
 	
-	bootcodepath = g_strdup_printf ("%s/bootcode.bin", folder);
+	bootcodepath = g_build_filename (folder, "bootcode.bin", NULL);
 
 	if (!g_file_test (bootcodepath, G_FILE_TEST_EXISTS))
 	{
@@ -306,7 +306,7 @@ static void showDialog()
 				if (imagepath)
 				{
 					/* Sanity check: check that image folder is present, and contains at least bootcode.bin */
-					bootcodepath = g_strdup_printf ("%s/bootcode.bin", imagepath);
+					bootcodepath = g_build_filename (imagepath, "bootcode.bin", NULL);
 
 					if (!g_file_test (imagepath, G_FILE_TEST_EXISTS))
 					{
@@ -476,7 +476,7 @@ static void addImage(const gchar *name, const gchar *folder)
 
 	gchar format[] = "%s<span size=\"smaller\">\n\n%s</span>";
 
-	descpath = g_strdup_printf ("%s/%s", folder, "description.txt");
+	descpath = g_build_filename (folder, "description.txt", NULL);
 	if (g_file_test (descpath, G_FILE_TEST_EXISTS))
 	{
 		gchar *desc;
@@ -493,7 +493,7 @@ static void addImage(const gchar *name, const gchar *folder)
 	}
 	g_free (descpath);
 
-	iconpath = g_strdup_printf ("%s/%s", folder, "icon.png");
+	iconpath = g_build_filename (folder, "icon.png", NULL);
 	if (g_file_test (iconpath, G_FILE_TEST_EXISTS)) {
 		icon = gdk_pixbuf_new_from_file(iconpath, NULL);
 	} else {
@@ -521,15 +521,15 @@ static void scanDirectory(const gchar *path)
 	const gchar *name;
 	GDir *rpibootdir;
 
-	rpibootpath = g_strdup_printf ("%s/rpiboot", path);
+	rpibootpath = g_build_filename (path, "rpiboot", NULL);
 	rpibootdir = g_dir_open(rpibootpath, 0, NULL);
 	if (!rpibootdir)
 		return;
 
 	while(name = g_dir_read_name(rpibootdir)) {
-		imagepath = g_strdup_printf ("%s/%s", rpibootpath, name);
+		imagepath = g_build_filename (rpibootpath, name, NULL);
 		if (g_file_test (imagepath, G_FILE_TEST_IS_DIR)) {
-			bootcodepath = g_strdup_printf ("%s/bootcode.bin", imagepath);
+			bootcodepath = g_build_filename (imagepath, "bootcode.bin", NULL);
 			if (g_file_test (bootcodepath, G_FILE_TEST_EXISTS)) {
 				addImage(name, imagepath);
 			}

--- a/src/usbbootgui.c
+++ b/src/usbbootgui.c
@@ -481,7 +481,7 @@ static void addImage(const gchar *name, const gchar *folder)
 	{
 		gchar *desc;
 		g_file_get_contents (descpath, &desc, NULL, NULL);
-		description = g_strdup_printf (format, desc, folder);
+		description = g_strdup_printf (format, g_strstrip (desc), folder);
 		g_free (desc);
 	} else {
 		if (g_strcmp0 (name, "gpioexpand") == 0)


### PR DESCRIPTION
This patch allows usbbootgui to dynamically load boot files at run
time. XDG standard directories are searched. Usually this means:

    /usr/share/rpiboot
    /usr/local/share/rpiboot
    ~/.local/share/rpiboot

The code first checks if the rpiboot/ subdirectory exists. If it
does, every subdirectory is checked for a bootcode.bin file. If
found, the directory is added to the list store.

If a description.txt is found in the directory, it is used as the
"friendly name" of the image. If an icon.png is found, it is loaded
as the icon. If not found, the directory name and a default icon
are used instead.

Both the description and path of the image are displayed in the GUI.
This is to distinguish between the same image in /usr/share and
/usr/local/share for example.

Images are now always refered to by their full paths. I have not
checked how this interacts with the "always use image" code, but I
think it should work. Old config files might have to be deleted.

This patch also allows the TreeView to have a scrollbar, and fixes
the "expand" property on a few items in the GUI, so that only the
TreeView expands when the window is resized.

Signed-off-by: Alistair Buxton <a.j.buxton@gmail.com>